### PR TITLE
Replace release name and use local helm

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -25,7 +25,7 @@ Each NIM contains an AI model, application, or workflow. All files necessary to 
 Available helm values can be discoved by running the `helm` command after the repo has been added.
 
 ```bash
-helm show values nim-llm
+helm show values nim-llm/
 ```
 
 The chart requires certain [Kubernetes secrets](https://kubernetes.io/docs/concepts/configuration/secret/) to be configured in the cluster.
@@ -88,7 +88,7 @@ kubectl create namespace inference-ms
 A command like the one below will then use the latest chart version to install the version of NIM defined in the values file into the `inference-ms` namespace in your Kubernetes cluster. Modify it as required.
 
 ```bash
-helm --namespace inference-ms install my-nim nim-llm -f path/to/your/custom-values.yaml
+helm --namespace inference-ms install my-nim nim-llm/ -f path/to/your/custom-values.yaml
 ```
 
 ### A Note on Storage

--- a/helm/README.md
+++ b/helm/README.md
@@ -14,12 +14,7 @@ export NGC_CLI_API_KEY="key from ngc"
 If you have not set up NGC, see the [NGC Setup](https://ngc.nvidia.com/setup) topic.
 
 [comment]: <> (TODO: update the repo with th real location)
-Add the helm repo with:
-
-```bash
-helm repo add nim-demo "https://nim-deploy.github.io/nvidia/nim-llm"
-```
-If using pre-release NIM, change the repo URL accordingly.
+Clone this repo to have this heml chart locally. Make sure you are in `nemo-deploy/helm`.
 
 ## Select a NIM to use in your helm release
 
@@ -30,7 +25,7 @@ Each NIM contains an AI model, application, or workflow. All files necessary to 
 Available helm values can be discoved by running the `helm` command after the repo has been added.
 
 ```bash
-helm show values nim-demo/nim-llm
+helm show values nim-llm
 ```
 
 The chart requires certain [Kubernetes secrets](https://kubernetes.io/docs/concepts/configuration/secret/) to be configured in the cluster.
@@ -56,7 +51,7 @@ Here is an example using meta/llama-3-8b-instruct.
 image:
   # Adjust to the actual location of the image and version you want
   repository: nvcr.io/nim/meta/llama3-8b-instruct
-  tag: 24.05
+  tag: 1.0.0
 imagePullSecrets:
   - name: registry-secret
 model:
@@ -93,7 +88,7 @@ kubectl create namespace inference-ms
 A command like the one below will then use the latest chart version to install the version of NIM defined in the values file into the `inference-ms` namespace in your Kubernetes cluster. Modify it as required.
 
 ```bash
-helm --namespace inference-ms install my-nim nim-demo/nim-llm -f path/to/your/custom-values.yaml
+helm --namespace inference-ms install my-nim nim-llm -f path/to/your/custom-values.yaml
 ```
 
 ### A Note on Storage

--- a/helm/nim-llm/README.md
+++ b/helm/nim-llm/README.md
@@ -11,7 +11,7 @@ To deploy a NIM, some custom values are generally required. Typically, this look
 ```yaml
 image:
     repository: "nvcr.io/nvidia/nim/nim-llm/meta-llama3-8b-instruct" # container location
-    tag: 24.05 # NIM version you want to deploy
+    tag: 1.0.0 # NIM version you want to deploy
 model:
   ngcAPISecret: ngc-api  # name of a secret in the cluster that includes a key named NGC_CLI_API_KEY and is an NGC API key
 resources:
@@ -158,7 +158,7 @@ Standard metrics of CPU and memory are of limited use in scaling NIM
 
 | Name                   | Description                                                                                                                                         | Value         |
 | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `model.legacyCompat`   | Set `true` to enable compatiblity with pre-release NIM versions prior to 24.05.                                                                     | `false`       |
+| `model.legacyCompat`   | Set `true` to enable compatiblity with pre-release NIM versions prior to 1.0.0.                                                                     | `false`       |
 | `model.numGpus`        | (deprecated) Specify GPU requirements for the model.                                                                                                | `1`           |
 | `model.subPath`        | (deprecated) Specify path within the model volume to mount if not the root -- default works with ngcInit and persistent volume. (legacyCompat only) | `model-store` |
 | `model.modelStorePath` | (deprecated) Specify location of unpacked model.                                                                                                    | `""`          |

--- a/helm/nim-llm/values.schema.json
+++ b/helm/nim-llm/values.schema.json
@@ -369,7 +369,7 @@
                 },
                 "legacyCompat": {
                     "type": "boolean",
-                    "description": "Set `true` to enable compatiblity with pre-release NIM versions prior to 24.05.",
+                    "description": "Set `true` to enable compatiblity with pre-release NIM versions prior to 1.0.0.",
                     "default": false
                 },
                 "numGpus": {

--- a/helm/nim-llm/values.yaml
+++ b/helm/nim-llm/values.yaml
@@ -50,7 +50,7 @@ image:
   repository: nvcr.io/nvidia/nim/nim_llm
   pullPolicy: IfNotPresent
   # Tag overrides the image tag whose default is the chart appVersion.
-  # tag: "24.04"
+  # tag: "1.0.0"
 
 ## @extra imagePullSecrets Specify list of secret names that are needed for the main container and any init containers.
 ## @skip imagePullSecrets[0].name
@@ -270,7 +270,7 @@ metrics:
 ## @param model.jsonLogging Turn jsonl logging on or off. Defaults to true.
 ## @param model.logLevel log level of NIM services. Defaults to INFO
 ## @section Deprecated and Legacy Model parameters
-## @param model.legacyCompat Set `true` to enable compatiblity with pre-release NIM versions prior to 24.05.
+## @param model.legacyCompat Set `true` to enable compatiblity with pre-release NIM versions prior to 1.0.0.
 ## @param model.numGpus (deprecated) Specify GPU requirements for the model.
 ## @param model.subPath (deprecated) Specify path within the model volume to mount if not the root -- default works with ngcInit and persistent volume. (legacyCompat only)
 ## @param model.modelStorePath (deprecated) Specify location of unpacked model.


### PR DESCRIPTION
This change removes all refernce to 24.0X and reference to the missing helm repo.