### PR TITLE
Bump KServe llama3 containers to 1.0.0 version and update cache location

### DIFF
--- a/kserve/runtimes/24.05-llama3-70b-instruct.yaml
+++ b/kserve/runtimes/24.05-llama3-70b-instruct.yaml
@@ -11,8 +11,8 @@ spec:
   containers:
   - env:
     - name: NIM_CACHE_PATH
-      value: /tmp
-      # value: /mnt/models/cache    - name: HF_TOKEN
+      value: /mnt/models/cache
+    - name: HF_TOKEN
       valueFrom:
         secretKeyRef:
           name: nvidia-nim-secrets
@@ -22,7 +22,7 @@ spec:
         secretKeyRef:
           name: nvidia-nim-secrets
           key: NGC_API_KEY
-    image: nvcr.io/mphexwv2ysej/meta-llama3-70b-instruct:24.05.rc11
+    image: nvcr.io/nim/meta/llama3-70b-instruct:1.0.0
     name: kserve-container
     ports:
     - containerPort: 8000

--- a/kserve/runtimes/24.05-llama3-8b-instruct.yaml
+++ b/kserve/runtimes/24.05-llama3-8b-instruct.yaml
@@ -11,8 +11,7 @@ spec:
   containers:
   - env:
     - name: NIM_CACHE_PATH
-      value: /tmp
-      # value: /mnt/models/cache
+      value: /mnt/models/cache
     - name: HF_TOKEN
       valueFrom:
         secretKeyRef:
@@ -23,7 +22,7 @@ spec:
         secretKeyRef:
           name: nvidia-nim-secrets
           key: NGC_API_KEY
-    image: nvcr.io/mphexwv2ysej/meta-llama3-8b-instruct:24.05.rc11
+    image: nvcr.io/nim/meta/llama3-8b-instruct:1.0.0
     name: kserve-container
     ports:
     - containerPort: 8000


### PR DESCRIPTION
- Bump to GA version of llama3 in KServe
- This adds support for RO volumes, so we remove the pointer to /tmp
- Also fix the HF token usage

