### PR TITLE
Set up the doc better and add the missing secrets template

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -31,7 +31,7 @@ helm show values nim-llm/
 
 See the chart's [readme](nim-llm/README.md) for information about the options, including their default values. Pay particular attention to the image.repository and image.tag options if you do not want to deploy the default image for this chart.
 
-You don't need a values file to run llama3-8b-instruct using the NIM 1.0.0 release. For an example, see [Launching a default NIM with minimal values](#Launching-a-default-NIM-with-minimal-values).
+You don't need a values file to run llama3-8b-instruct using the NIM 1.0.0 release. For an example, see [Launching a default NIM with minimal values](#Launching-a-NIM-with-a-minimal-configuration).
 
 ## Create a namespace
 

--- a/helm/nim-llm/templates/secrets.yaml
+++ b/helm/nim-llm/templates/secrets.yaml
@@ -1,0 +1,23 @@
+{{ if .Values.model.ngcAPIKey }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nvcrimagepullsecret
+  labels:
+    {{- include "nim-llm.labels" . | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "nim-llm.generatedImagePullSecret" . }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ngc-api
+  labels:
+    {{- include "nim-llm.labels" . | nindent 4 }}
+type: Opaque
+data:
+  NGC_CLI_API_KEY: {{ .Values.model.ngcAPIKey | b64enc }}
+---
+{{ end }}


### PR DESCRIPTION
This is primarily a getting-started doc rehash. This corrects several issues with consistency, reorders things a bit, and offers the simplest option with where to go for more information.

In the last PR, the new secrets file option was missed, so that is corrected here.