### PR TITLE
helm: Fix service name reference in Ingress template

### DIFF
--- a/helm/nim-llm/templates/ingress.yaml
+++ b/helm/nim-llm/templates/ingress.yaml
@@ -8,13 +8,7 @@
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
   {{- end }}
 {{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -25,7 +19,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   {{- if .Values.ingress.tls }}
@@ -50,7 +44,7 @@ spec:
             {{- end }}
             backend:
               service:
-                name: "{{ $fullName }}-{{ .serviceType }}"
+                name: "{{ $fullName }}"
                 port:
                   {{- if eq .serviceType "nemo" }}
                   number: {{ $nemoPort }}


### PR DESCRIPTION
The ingress template expects the .serviceType to be suffixed on the service name reference in the hosts portion of the manifest, but the service template does not apply this suffix.

This further cleans up the conditions over the associated kubernetes version checks in the ingress template as the chart currently requires k8s>=1.23 [here](https://github.com/NVIDIA/nim-deploy/blob/main/helm/nim-llm/Chart.yaml#L5).

🤙