### PR TITLE
General KServe cleanup / improvements based on review

### DIFF
--- a/kserve/nim-models/llama3-70b-instruct_4xa100_1.0.0.yaml
+++ b/kserve/nim-models/llama3-70b-instruct_4xa100_1.0.0.yaml
@@ -18,5 +18,5 @@ spec:
       runtime: nvidia-nim-llama3-70b-instruct-1.0.0
       storageUri: pvc://nvidia-nim-pvc/
     nodeSelector:
-      nvidia.com/gpu.product: A100-SXM4-80GB
+      nvidia.com/gpu.product: NVIDIA-A100-SXM4-80GB
 

--- a/kserve/nim-models/llama3-70b-instruct_4xh100_1.0.0.yaml
+++ b/kserve/nim-models/llama3-70b-instruct_4xh100_1.0.0.yaml
@@ -18,5 +18,5 @@ spec:
       runtime: nvidia-nim-llama3-70b-instruct-1.0.0
       storageUri: pvc://nvidia-nim-pvc/
     nodeSelector:
-      nvidia.com/gpu.product: H100-SXM4-80GB
+      nvidia.com/gpu.product: NVIDIA-H100-SXM4-80GB
 

--- a/kserve/nim-models/llama3-8b-instruct_2h100_1.0.0.yaml
+++ b/kserve/nim-models/llama3-8b-instruct_2h100_1.0.0.yaml
@@ -18,4 +18,4 @@ spec:
       runtime: nvidia-nim-llama3-8b-instruct-1.0.0
       storageUri: pvc://nvidia-nim-pvc/
     nodeSelector:
-      nvidia.com/gpu.product: H100-SXM4-80GB
+      nvidia.com/gpu.product: NVIDIA-H100-SXM4-80GB

--- a/kserve/nim-models/llama3-8b-instruct_2xa100_1.0.0.yaml
+++ b/kserve/nim-models/llama3-8b-instruct_2xa100_1.0.0.yaml
@@ -18,5 +18,5 @@ spec:
       runtime: nvidia-nim-llama3-8b-instruct-1.0.0
       storageUri: pvc://nvidia-nim-pvc/
     nodeSelector:
-      nvidia.com/gpu.product: A100-SXM4-80GB
+      nvidia.com/gpu.product: NVIDIA-A100-SXM4-80GB
 


### PR DESCRIPTION
General cleanup and usability improvement PR for KServe based on a review.


* Fix the nvidia.com/gpu.product tags. They needed to include "NVIDIA-" to be valid on DGX.