### PR TITLE
Add support for customArgs and fix customCommand

### DIFF
--- a/helm/nim-llm/templates/deployment.yaml
+++ b/helm/nim-llm/templates/deployment.yaml
@@ -100,7 +100,7 @@ spec:
           command:
             {{- if .Values.customCommand }}
             {{- range .Values.customCommand }}
-             - {{ . }}
+             - {{ . | quote }}
             {{- end }}
             {{- else }}
             - nemollm_inference_ms
@@ -153,6 +153,14 @@ spec:
             {{- if .Values.model.modelStorePath }}
             - --model_store_path
             - {{ .Values.model.modelStorePath | quote }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.customArgs }}
+          args:
+            {{- if .Values.customArgs }}
+            {{- range .Values.customArgs }}
+             - {{ . | quote }}
             {{- end }}
             {{- end }}
           {{- end }}

--- a/helm/nim-llm/values.schema.json
+++ b/helm/nim-llm/values.schema.json
@@ -2,6 +2,14 @@
     "title": "Chart Values",
     "type": "object",
     "properties": {
+        "customArgs": {
+            "type": "array",
+            "description": "overrides args of the NeMo Inference service container with the array listed here. ",
+            "default": "[]",
+            "items": {
+                "type": "string"
+            }
+        },
         "customCommand": {
             "type": "array",
             "description": "overrides command line options sent to the NeMo Inference service with the array listed here. ",

--- a/helm/nim-llm/values.yaml
+++ b/helm/nim-llm/values.yaml
@@ -18,6 +18,10 @@ containerSecurityContext: {}
   # seccompProfile:
   #   type: "RuntimeDefault"
 
+## @param customArgs [array] overrides args of the NeMo Inference service container with the array listed here. 
+## For andvanced use if necessary only
+customArgs: []
+
 ## @param customCommand [array] overrides command line options sent to the NeMo Inference service with the array listed here. 
 ## For andvanced use if necessary only
 customCommand: []


### PR DESCRIPTION
Add support to override the default command of the NIM container image using `customArgs`.

This is for advanced use cases.