### PR TITLE
Add additional LLM NIMs from the latest 1.1.0 and 1.0.0 releases for KServe

### DIFF
--- a/kserve/nim-models/llama-3.1-70b-instruct_2xgpu_1.1.0.yaml
+++ b/kserve/nim-models/llama-3.1-70b-instruct_2xgpu_1.1.0.yaml
@@ -1,0 +1,19 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  annotations:
+    autoscaling.knative.dev/target: "10"
+  name: llama-3-1-70b-instruct-2xgpu
+spec:
+  predictor:
+    minReplicas: 1
+    model:
+      modelFormat:
+        name: nvidia-nim-llama-3.1-70b-instruct
+      resources:
+        limits:
+          nvidia.com/gpu: "2"
+        requests:
+          nvidia.com/gpu: "2"
+      runtime: nvidia-nim-llama-3.1-70b-instruct-1.1.0
+      storageUri: pvc://nvidia-nim-pvc/

--- a/kserve/nim-models/mistral-7b-instruct-v03_1xgpu_1.0.0.yaml
+++ b/kserve/nim-models/mistral-7b-instruct-v03_1xgpu_1.0.0.yaml
@@ -1,0 +1,19 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  annotations:
+    autoscaling.knative.dev/target: "10"
+  name: mistral-7b-instruct-v03-1xgpu
+spec:
+  predictor:
+    minReplicas: 1
+    model:
+      modelFormat:
+        name: nvidia-nim-mistral-7b-instruct-v03
+      resources:
+        limits:
+          nvidia.com/gpu: "1"
+        requests:
+          nvidia.com/gpu: "1"
+      runtime: nvidia-nim-mistral-7b-instruct-v03-1.0.0
+      storageUri: pvc://nvidia-nim-pvc/

--- a/kserve/nim-models/mixtral-8x22b-instruct-v01_8xgpu_1.0.0.yaml
+++ b/kserve/nim-models/mixtral-8x22b-instruct-v01_8xgpu_1.0.0.yaml
@@ -1,0 +1,19 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  annotations:
+    autoscaling.knative.dev/target: "10"
+  name: mixtral-8x22b-instruct-v01-8xgpu
+spec:
+  predictor:
+    minReplicas: 1
+    model:
+      modelFormat:
+        name: nvidia-nim-mixtral-8x22b-instruct-v01
+      resources:
+        limits:
+          nvidia.com/gpu: "8"
+        requests:
+          nvidia.com/gpu: "8"
+      runtime: nvidia-nim-mixtral-8x22b-instruct-v01-1.0.0
+      storageUri: pvc://nvidia-nim-pvc/

--- a/kserve/nim-models/mixtral-8x7b-instruct-v01_2xgpu_1.0.0.yaml
+++ b/kserve/nim-models/mixtral-8x7b-instruct-v01_2xgpu_1.0.0.yaml
@@ -1,0 +1,19 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  annotations:
+    autoscaling.knative.dev/target: "10"
+  name: mixtral-8x7b-instruct-v01-2xgpu
+spec:
+  predictor:
+    minReplicas: 1
+    model:
+      modelFormat:
+        name: nvidia-nim-mixtral-8x7b-instruct-v01
+      resources:
+        limits:
+          nvidia.com/gpu: "2"
+        requests:
+          nvidia.com/gpu: "2"
+      runtime: nvidia-nim-mixtral-8x7b-instruct-v01-1.0.0
+      storageUri: pvc://nvidia-nim-pvc/

--- a/kserve/runtimes/llama-3.1-70b-instruct-1.1.0.yaml
+++ b/kserve/runtimes/llama-3.1-70b-instruct-1.1.0.yaml
@@ -1,0 +1,54 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  name: nvidia-nim-llama-3.1-70b-instruct-1.1.0
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8000"
+    serving.kserve.io/enable-metric-aggregation: "true"
+    serving.kserve.io/enable-prometheus-scraping: "true"
+  containers:
+  - env:
+    - name: NIM_CACHE_PATH
+      value: /mnt/models/cache
+    - name: HF_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: nvidia-nim-secrets
+          key: HF_TOKEN
+    - name: NGC_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: nvidia-nim-secrets
+          key: NGC_API_KEY
+    image: nvcr.io/nim/meta/llama-3.1-70b-instruct:1.1.0
+    name: kserve-container
+    ports:
+    - containerPort: 8000
+      protocol: TCP
+    resources:
+      limits:
+        cpu: "12"
+        memory: 32Gi
+      requests:
+        cpu: "12"
+        memory: 32Gi
+    volumeMounts:
+    - mountPath: /dev/shm
+      name: dshm
+  imagePullSecrets:
+  - name: ngc-secret
+  protocolVersions:
+  - v2
+  - grpc-v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: nvidia-nim-llama-3.1-70b-instruct
+    priority: 1
+    version: "1.0.0"
+  volumes:
+  - emptyDir:
+      medium: Memory
+      sizeLimit: 16Gi
+    name: dshm

--- a/kserve/runtimes/llama-3.1-70b-instruct-1.1.0.yaml
+++ b/kserve/runtimes/llama-3.1-70b-instruct-1.1.0.yaml
@@ -46,7 +46,7 @@ spec:
   - autoSelect: true
     name: nvidia-nim-llama-3.1-70b-instruct
     priority: 1
-    version: "1.0.0"
+    version: "1.1.0"
   volumes:
   - emptyDir:
       medium: Memory

--- a/kserve/runtimes/llama-3.1-8b-instruct-1.1.0.yaml
+++ b/kserve/runtimes/llama-3.1-8b-instruct-1.1.0.yaml
@@ -1,7 +1,7 @@
 apiVersion: serving.kserve.io/v1alpha1
 kind: ClusterServingRuntime
 metadata:
-  name: nvidia-nim-llama3-8b-instruct-1.0.0
+  name: nvidia-nim-llama-3.1-8b-instruct-1.1.0
 spec:
   annotations:
     prometheus.kserve.io/path: /metrics
@@ -22,7 +22,7 @@ spec:
         secretKeyRef:
           name: nvidia-nim-secrets
           key: NGC_API_KEY
-    image: nvcr.io/nim/meta/llama3-8b-instruct:1.0.0
+    image: nvcr.io/nim/meta/llama-3.1-8b-instruct:1.1.0
     name: kserve-container
     ports:
     - containerPort: 8000
@@ -44,9 +44,9 @@ spec:
   - grpc-v2
   supportedModelFormats:
   - autoSelect: true
-    name: nvidia-nim-llama3-8b-instruct
+    name: nvidia-nim-llama-3.1-8b-instruct
     priority: 1
-    version: "1.0.0"
+    version: "1.1.0"
   volumes:
   - emptyDir:
       medium: Memory

--- a/kserve/runtimes/mistral-7b-instruct-v03-1.0.0.yaml
+++ b/kserve/runtimes/mistral-7b-instruct-v03-1.0.0.yaml
@@ -1,0 +1,54 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  name: nvidia-nim-mistral-7b-instruct-v03-1.0.0
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8000"
+    serving.kserve.io/enable-metric-aggregation: "true"
+    serving.kserve.io/enable-prometheus-scraping: "true"
+  containers:
+  - env:
+    - name: NIM_CACHE_PATH
+      value: /mnt/models/cache
+    - name: HF_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: nvidia-nim-secrets
+          key: HF_TOKEN
+    - name: NGC_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: nvidia-nim-secrets
+          key: NGC_API_KEY
+    image: nvcr.io/nim/mistralai/mistral-7b-instruct-v03:1.0.0
+    name: kserve-container
+    ports:
+    - containerPort: 8000
+      protocol: TCP
+    resources:
+      limits:
+        cpu: "12"
+        memory: 32Gi
+      requests:
+        cpu: "12"
+        memory: 32Gi
+    volumeMounts:
+    - mountPath: /dev/shm
+      name: dshm
+  imagePullSecrets:
+  - name: ngc-secret
+  protocolVersions:
+  - v2
+  - grpc-v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: nvidia-nim-mistral-7b-instruct-v03
+    priority: 1
+    version: "1.0.0"
+  volumes:
+  - emptyDir:
+      medium: Memory
+      sizeLimit: 16Gi
+    name: dshm

--- a/kserve/runtimes/mixtral-8x22b-instruct-v01-1.0.0.yaml
+++ b/kserve/runtimes/mixtral-8x22b-instruct-v01-1.0.0.yaml
@@ -1,0 +1,54 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  name: nvidia-nim-mixtral-8x22b-instruct-v01-1.0.0
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8000"
+    serving.kserve.io/enable-metric-aggregation: "true"
+    serving.kserve.io/enable-prometheus-scraping: "true"
+  containers:
+  - env:
+    - name: NIM_CACHE_PATH
+      value: /mnt/models/cache
+    - name: HF_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: nvidia-nim-secrets
+          key: HF_TOKEN
+    - name: NGC_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: nvidia-nim-secrets
+          key: NGC_API_KEY
+    image: nvcr.io/nim/mistralai/mixtral-8x22b-instruct-v01:1.0.0
+    name: kserve-container
+    ports:
+    - containerPort: 8000
+      protocol: TCP
+    resources:
+      limits:
+        cpu: "12"
+        memory: 32Gi
+      requests:
+        cpu: "12"
+        memory: 32Gi
+    volumeMounts:
+    - mountPath: /dev/shm
+      name: dshm
+  imagePullSecrets:
+  - name: ngc-secret
+  protocolVersions:
+  - v2
+  - grpc-v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: nvidia-nim-mixtral-8x22b-instruct-v01
+    priority: 1
+    version: "1.0.0"
+  volumes:
+  - emptyDir:
+      medium: Memory
+      sizeLimit: 16Gi
+    name: dshm

--- a/kserve/runtimes/mixtral-8x7b-instruct-v01-1.0.0.yaml
+++ b/kserve/runtimes/mixtral-8x7b-instruct-v01-1.0.0.yaml
@@ -1,0 +1,54 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  name: nvidia-nim-mixtral-8x7b-instruct-v01-1.0.0
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8000"
+    serving.kserve.io/enable-metric-aggregation: "true"
+    serving.kserve.io/enable-prometheus-scraping: "true"
+  containers:
+  - env:
+    - name: NIM_CACHE_PATH
+      value: /mnt/models/cache
+    - name: HF_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: nvidia-nim-secrets
+          key: HF_TOKEN
+    - name: NGC_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: nvidia-nim-secrets
+          key: NGC_API_KEY
+    image: nvcr.io/nim/mistralai/mixtral-8x7b-instruct-v01:1.0.0
+    name: kserve-container
+    ports:
+    - containerPort: 8000
+      protocol: TCP
+    resources:
+      limits:
+        cpu: "12"
+        memory: 32Gi
+      requests:
+        cpu: "12"
+        memory: 32Gi
+    volumeMounts:
+    - mountPath: /dev/shm
+      name: dshm
+  imagePullSecrets:
+  - name: ngc-secret
+  protocolVersions:
+  - v2
+  - grpc-v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: nvidia-nim-mixtral-8x7b-instruct-v01
+    priority: 1
+    version: "1.0.0"
+  volumes:
+  - emptyDir:
+      medium: Memory
+      sizeLimit: 16Gi
+    name: dshm

--- a/kserve/scripts/download-all.yaml
+++ b/kserve/scripts/download-all.yaml
@@ -22,7 +22,7 @@ spec:
               key: NGC_API_KEY    
         volumeMounts:
         - name: model-cache
-          mountPath: /mnt/models/cache
+          mountPath: /mnt/models
       imagePullSecrets:
       - name: ngc-secret
       volumes:

--- a/kserve/scripts/download-profile.yaml
+++ b/kserve/scripts/download-profile.yaml
@@ -24,7 +24,7 @@ spec:
               key: NGC_API_KEY    
         volumeMounts:
         - name: model-cache
-          mountPath: /mnt/models/cache
+          mountPath: /mnt/models
       imagePullSecrets:
       - name: ngc-secret
       volumes:

--- a/kserve/scripts/download-single.yaml
+++ b/kserve/scripts/download-single.yaml
@@ -22,7 +22,7 @@ spec:
               key: NGC_API_KEY    
         volumeMounts:
         - name: model-cache
-          mountPath: /mnt/models/cache
+          mountPath: /mnt/models/
 
         # Update the number of GPUs desired for production deployment
         resources:


### PR DESCRIPTION
* llama 3.1-70b 1.1.0
* mistral-7b-instruct-v03 1.0.0
* minor bugfixes
* mixtral-8x7b-instruct-v01
* mixtral-8x22b-instruct-v01