### PR TITLE
fix: rename ngc api key;issue #82

### DIFF
--- a/cloud-service-providers/google-cloud/gke/README.md
+++ b/cloud-service-providers/google-cloud/gke/README.md
@@ -107,7 +107,7 @@ cd nim-deploy/cloud-service-providers/google-cloud/gke
   | Variable | Description | Default | Need update? |
   |---|---|---|---|
   | `registry_server` | NVIDIA Registry that hosts the images | `nvcr.io` | *No* |
-  | `ngc_api_key` | NGC API Key from NVIDIA | <> | *Yes* |
+  | `ngc_api_key` | NGC API Key | <> | *Yes* |
   | `repository` | NIM image | `nvcr.io/nim/meta/llama3-8b-instruct` | *No* |
   | `tag` | Tag of image | `1.0.0` | *No* |
   | `model_name` | NIM Model name | `meta/llama3-8b-instruct` | *No* |

--- a/cloud-service-providers/google-cloud/gke/README.md
+++ b/cloud-service-providers/google-cloud/gke/README.md
@@ -107,7 +107,7 @@ cd nim-deploy/cloud-service-providers/google-cloud/gke
   | Variable | Description | Default | Need update? |
   |---|---|---|---|
   | `registry_server` | NVIDIA Registry that hosts the images | `nvcr.io` | *No* |
-  | `ngc_cli_api_key` | NGC API Key from NVIDIA | <> | *Yes* |
+  | `ngc_api_key` | NGC API Key from NVIDIA | <> | *Yes* |
   | `repository` | NIM image | `nvcr.io/nim/meta/llama3-8b-instruct` | *No* |
   | `tag` | Tag of image | `1.0.0` | *No* |
   | `model_name` | NIM Model name | `meta/llama3-8b-instruct` | *No* |
@@ -163,7 +163,7 @@ export NGC_API_KEY=<Your API KEY>
 
 helm --namespace nim install my-nim ../../../helm/nim-llm/ \
 -f ./infra/3-config/helm/custom-values.yaml \
---set model.ngcAPIKey=$NGC_CLI_API_KEY
+--set model.ngcAPIKey=$NGC_API_KEY
 ```
 
 4.Port forward to local at 8000 (change as needed) and update in the curl command as well.

--- a/cloud-service-providers/google-cloud/gke/infra/3-config/main.tf
+++ b/cloud-service-providers/google-cloud/gke/infra/3-config/main.tf
@@ -67,8 +67,8 @@ resource "kubernetes_secret" "registry_secret" {
       "auths" = {
         "${var.registry_server}" = {
           "username" = var.ngc_username
-          "password" = var.ngc_cli_api_key
-          "auth"     = base64encode("${var.ngc_username}:${var.ngc_cli_api_key}")
+          "password" = var.ngc_api_key
+          "auth"     = base64encode("${var.ngc_username}:${var.ngc_api_key}")
         }
       }
     })
@@ -86,7 +86,7 @@ resource "kubernetes_secret" "ngc_api" {
   type = "Opaque" # Generic secret type
 
   data = {
-    "NGC_CLI_API_KEY" = var.ngc_cli_api_key
+    "NGC_API_KEY" = var.ngc_api_key
   }
 
   depends_on = [kubernetes_namespace.nim]

--- a/cloud-service-providers/google-cloud/gke/infra/3-config/terraform.auto.tfvars
+++ b/cloud-service-providers/google-cloud/gke/infra/3-config/terraform.auto.tfvars
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ngc_cli_api_key = "<NGC CLI API Key>"
+ngc_api_key = "<NGC CLI API Key>"
 registry_server = "nvcr.io"
 repository      = "nvcr.io/nim/meta/llama3-8b-instruct"
 tag             = "1.0.0"

--- a/cloud-service-providers/google-cloud/gke/infra/3-config/variables.tf
+++ b/cloud-service-providers/google-cloud/gke/infra/3-config/variables.tf
@@ -26,10 +26,10 @@ variable "ngc_username" {
   sensitive   = true
 }
 
-variable "ngc_cli_api_key" {
+variable "ngc_api_key" {
   type        = string
-  default     = "$NGC_CLI_API_KEY"
-  description = "NGC CLI API key to access NGC registry"
+  default     = "$NGC_API_KEY"
+  description = "NGC API key to access NGC registry"
   sensitive   = true
 }
 


### PR DESCRIPTION

The variable name "NGC_CLI_API_KEY" needs to be updated to "NGC_API_KEY". Issue here: https://github.com/NVIDIA/nim-deploy/issues/82

https://github.com/NVIDIA/nim-deploy/blob/main/cloud-service-providers/google-cloud/gke/infra/3-config/main.tf
line 89:
NGC_CLI_API_KEY => NGC_API_KEY