### PR TITLE
Fix invalid secret key name in GKE TF

### DIFF
--- a/cloud-service-providers/google-cloud/gke/infra/3-config/main.tf
+++ b/cloud-service-providers/google-cloud/gke/infra/3-config/main.tf
@@ -86,7 +86,7 @@ resource "kubernetes_secret" "ngc_api" {
   type = "Opaque" # Generic secret type
 
   data = {
-    "NGC_CLI_API_KEY" = var.ngc_cli_api_key
+    "NGC_API_KEY" = var.ngc_cli_api_key
   }
 
   depends_on = [kubernetes_namespace.nim]


### PR DESCRIPTION
`NGC_API_KEY` is referenced in the [parent helm chart](https://github.com/NVIDIA/nim-deploy/blob/main/helm/nim-llm/templates/secrets.yaml#L21). Current GKE TF automation incorrectly references `NGC_CLI_API_KEY` introducing a failure during helm deployment.