### PR TITLE
fix: gke version,gpu driver version updates

### DIFF
--- a/cloud-service-providers/google-cloud/gke/README.md
+++ b/cloud-service-providers/google-cloud/gke/README.md
@@ -222,7 +222,7 @@ curl -X 'POST' \
   "top_p": 1,
   "n": 1,
   "stream": false,
-  "stop": "\n",
+  "stop": "",
   "frequency_penalty": 0.0
 }'
 ```

--- a/cloud-service-providers/google-cloud/gke/infra/2-setup/terraform.auto.tfvars
+++ b/cloud-service-providers/google-cloud/gke/infra/2-setup/terraform.auto.tfvars
@@ -53,5 +53,5 @@ gpu_pools = [
     disk_type          = "pd-balanced"
     enable_gcfs        = true
     logging_variant    = "DEFAULT"
-    gpu_driver_version = "DEFAULT"
+    gpu_driver_version = "LATEST"
 }]

--- a/cloud-service-providers/google-cloud/gke/infra/2-setup/variables.tf
+++ b/cloud-service-providers/google-cloud/gke/infra/2-setup/variables.tf
@@ -85,7 +85,7 @@ variable "cluster_labels" {
 
 variable "kubernetes_version" {
   type    = string
-  default = "1.28"
+  default = "1.31"
 }
 
 variable "release_channel" {


### PR DESCRIPTION
1. Updated default version of GKE to 1.31
2. Install GPU latest driver
3. Remove `\n` typo in test inference