### PR TITLE
upgrade helm and point script to ngc registry

### DIFF
--- a/cloud-service-providers/google-cloud/gke/README.md
+++ b/cloud-service-providers/google-cloud/gke/README.md
@@ -172,9 +172,14 @@ Update [custom-values.yaml](./infra/3-config/helm/custom-values.yaml) file
 ```shell
 export NGC_API_KEY=<Your API KEY>
 
-helm --namespace nim install my-nim ../../../helm/nim-llm/ \
--f ./infra/3-config/helm/custom-values.yaml \
---set model.ngcAPIKey=$NGC_API_KEY
+helm --namespace nim install my-nim \
+    --repo https://helm.ngc.nvidia.com/nim \
+    --username='$oauthtoken' \
+    --password=$NGC_API_KEY \
+    nim-llm \
+    --version 1.3.0 \
+    -f ./infra/3-config/helm/custom-values.yaml \
+    --set model.ngcAPIKey=$NGC_API_KEY
 ```
 
 4.Port forward to local at 8000 (change as needed) and update in the curl command as well.

--- a/cloud-service-providers/google-cloud/gke/infra/2-setup/variables.tf
+++ b/cloud-service-providers/google-cloud/gke/infra/2-setup/variables.tf
@@ -85,7 +85,7 @@ variable "cluster_labels" {
 
 variable "kubernetes_version" {
   type    = string
-  default = "1.28"
+  default = "latest"
 }
 
 variable "release_channel" {

--- a/cloud-service-providers/google-cloud/gke/infra/3-config/main.tf
+++ b/cloud-service-providers/google-cloud/gke/infra/3-config/main.tf
@@ -175,8 +175,12 @@ resource "helm_release" "ngc_to_gcs_transfer" {
 resource "helm_release" "my_nim" {
   name       = "my-nim"
   namespace  = "nim"
-  repository = "nim-llm"
-  chart      = "../../../../../helm/nim-llm/"
+  repository = "https://helm.ngc.nvidia.com/nim"
+  chart      = "nim-llm"
+  version    = "1.3.0"
+
+  repository_username = "$oauthtoken"
+  repository_password = var.ngc_api_key
 
   values = [
     file("./helm/custom-values.yaml")
@@ -216,7 +220,6 @@ resource "helm_release" "my_nim" {
 
   timeout = 900
   wait    = true
-
 }
 
 # resource "kubernetes_service" "my_nim_service" {

--- a/cloud-service-providers/google-cloud/gke/infra/3-config/terraform.auto.tfvars
+++ b/cloud-service-providers/google-cloud/gke/infra/3-config/terraform.auto.tfvars
@@ -15,6 +15,6 @@
 ngc_api_key = "<NGC API Key>"
 registry_server = "nvcr.io"
 repository      = "nvcr.io/nim/meta/llama3-8b-instruct"
-tag             = "1.0.0"
+tag             = "1.0.3"
 model_name      = "meta/llama3-8b-instruct"
 gpu_limits      = 1


### PR DESCRIPTION
This PR:
- Upgrades HELM to latest 1.3.0 version
- Point helm chart fetching to NGC Registry instead of using loca copy which should be deprecated now
- Upgrades GKE version