### PR TITLE
Deprecate migrated Google Cloud samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+> [!IMPORTANT]
+> This repository is being deprecated as the canonical home for cloud service provider samples. New and maintained CSP samples are moving to dedicated sample repositories:
+>
+> - [NVIDIA Google Cloud samples](https://github.com/NVIDIA/nvidia-gcp-samples)
+> - [NVIDIA Azure samples](https://github.com/NVIDIA/nvidia-azure-samples)
+> - [NVIDIA OCI samples](https://github.com/NVIDIA/nvidia-oci-samples)
+> - [NVIDIA AWS samples](https://github.com/NVIDIA/nvidia-aws-samples)
+>
+> Existing content in this repository remains available for reference, but new CSP sample development should happen in the destination repositories.
+
 ## Introduction
 This repo showcases different ways NVIDIA NIMs can be deployed. This repo contains reference implementations, example documents, and architecture guides that can be used as a starting point to deploy multiple NIMs and other NVIDIA microservices into Kubernetes and other production deployment environments.
 

--- a/cloud-service-providers/google-cloud/cloudrun/nim-cosmosreason/README.md
+++ b/cloud-service-providers/google-cloud/cloudrun/nim-cosmosreason/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample has moved to `nvidia-gcp-samples`. This copy in `nim-deploy` is deprecated and is no longer the canonical reference. Use the maintained sample at <https://github.com/NVIDIA/nvidia-gcp-samples/tree/master/inference/cloud-run/nim/cosmos-reason>.
+
 # Deploying NIMs to Google Cloud Run using RTX PRO 6000
 
 This guide outlines the steps to deploy a NIM LLM to Google Cloud Run, using Cosmos Reason 2 8B as an example.

--- a/cloud-service-providers/google-cloud/cloudrun/nim-llama/README.md
+++ b/cloud-service-providers/google-cloud/cloudrun/nim-llama/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample has moved to `nvidia-gcp-samples`. This copy in `nim-deploy` is deprecated and is no longer the canonical reference. Use the maintained sample at <https://github.com/NVIDIA/nvidia-gcp-samples/tree/master/inference/cloud-run/nim/llama>.
+
 # Deploying NIMs to Google Cloud Run
 
 This guide outlines the steps to deploy a NIM LLM to Google Cloud Run.

--- a/cloud-service-providers/google-cloud/cloudrun/nim-nemotron/README.md
+++ b/cloud-service-providers/google-cloud/cloudrun/nim-nemotron/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample has moved to `nvidia-gcp-samples`. This copy in `nim-deploy` is deprecated and is no longer the canonical reference. Use the maintained sample at <https://github.com/NVIDIA/nvidia-gcp-samples/tree/master/inference/cloud-run/nim/nemotron>.
+
 # Deploying NIMs to Google Cloud Run using RTX PRO 6000
 
 This guide outlines the steps to deploy a NIM LLM to Google Cloud Run, using Nemotron V3 30B as an example.

--- a/cloud-service-providers/google-cloud/gke/gcloud/README.md
+++ b/cloud-service-providers/google-cloud/gke/gcloud/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample has moved to `nvidia-gcp-samples`. This copy in `nim-deploy` is deprecated and is no longer the canonical reference. Use the maintained sample at <https://github.com/NVIDIA/nvidia-gcp-samples/tree/master/inference/gke/nim/llm-nim/gcloud>.
+
 # Deploy NVIDIA NIM on Google Kubernetes Engine
 
 ## Introduction

--- a/cloud-service-providers/google-cloud/gke/terraform/README.md
+++ b/cloud-service-providers/google-cloud/gke/terraform/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample has moved to `nvidia-gcp-samples`. This copy in `nim-deploy` is deprecated and is no longer the canonical reference. Use the maintained sample at <https://github.com/NVIDIA/nvidia-gcp-samples/tree/master/inference/gke/nim/llm-nim>.
+
 # NVIDIA NIMs on GKE
 
 This repository sets up a GKE cluster with node pools equipped with NVIDIA GPUs for hosting NIMs and carrying out inference. Meta's [llama3-8b-instruct NIM](https://build.nvidia.com/meta/llama3-8b) serves as a demonstration model in this instance. The repository references the NVIDIA-provided [helm charts](https://github.com/NVIDIA/nim-deploy/tree/main/helm).

--- a/cloud-service-providers/google-cloud/industry-solutions/RAG/README.md
+++ b/cloud-service-providers/google-cloud/industry-solutions/RAG/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample has moved to `nvidia-gcp-samples`. This copy in `nim-deploy` is deprecated and is no longer the canonical reference. Use the maintained sample at <https://github.com/NVIDIA/nvidia-gcp-samples/tree/master/industry-solutions/gke/rag>.
+
 
 *Disclaimer: This sample is based on this [repository](https://github.com/NVIDIA-AI-Blueprints/rag). For the most up to date information, licensing, and terms of use please refer to it.*
 

--- a/cloud-service-providers/google-cloud/industry-solutions/bionemo-drug-discovery/README.md
+++ b/cloud-service-providers/google-cloud/industry-solutions/bionemo-drug-discovery/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample has moved to `nvidia-gcp-samples`. This copy in `nim-deploy` is deprecated and is no longer the canonical reference. Use the maintained sample at <https://github.com/NVIDIA/nvidia-gcp-samples/tree/master/industry-solutions/gke/bionemo-drug-discovery>.
+
 # NVIDIA BioNeMo Blueprint: Generative Virtual Screening for Drug Discovery
 
 *Disclaimer: This sample is based on this [repository](https://github.com/NVIDIA-BioNeMo-blueprints/generative-virtual-screening). For the most up to date information, please refer to it.*

--- a/cloud-service-providers/google-cloud/industry-solutions/video-search-and-summarization/gce/README.md
+++ b/cloud-service-providers/google-cloud/industry-solutions/video-search-and-summarization/gce/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample has moved to `nvidia-gcp-samples`. This copy in `nim-deploy` is deprecated and is no longer the canonical reference. Use the maintained sample at <https://github.com/NVIDIA/nvidia-gcp-samples/tree/master/industry-solutions/compute-engine/video-search-and-summarization>.
+
 # Deploy NVIDIA VSS Blueprint with Helm on Google Compute Engine
 
 ## Introduction

--- a/cloud-service-providers/google-cloud/vertexai/python/README.md
+++ b/cloud-service-providers/google-cloud/vertexai/python/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample has moved to `nvidia-gcp-samples`. This copy in `nim-deploy` is deprecated and is no longer the canonical reference. Use the maintained sample at <https://github.com/NVIDIA/nvidia-gcp-samples/tree/master/inference/agent-platform/nim/llm-nim/python>.
+
 # NVIDIA NIM on GCP Vertex AI
 
 **NVIDIA NIM** is a set of microservices designed to accelerate the deployment of generative AI models across the cloud, data center, and workstations. NIMs are categorized by model family and a per model basis. Leveraging NVIDIA’s GPU acceleration on Google Cloud Platform, NIM offers an efficient and scalable path to inference with unparalleled performance.


### PR DESCRIPTION
## Summary
- Mark migrated Google Cloud sample READMEs as deprecated in nim-deploy
- Link each deprecated sample to its maintained location in NVIDIA/nvidia-gcp-samples

## Notes
- This PR updates tracked README files only
- The local untracked physical-ai-isaac-lab-newton folder was not included