### PR TITLE
Deprecate Azure samples

### DIFF
--- a/cloud-service-providers/azure/aks/README.md
+++ b/cloud-service-providers/azure/aks/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained Azure samples are available at <https://github.com/NVIDIA/nvidia-azure-samples>.
+
 # NIM on Azure Kubernetes Service (AKS)
 
 

--- a/cloud-service-providers/azure/azureml/README.md
+++ b/cloud-service-providers/azure/azureml/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained Azure samples are available at <https://github.com/NVIDIA/nvidia-azure-samples>.
+
 # Deploying NIMs on AzureML
 
 - **Using Azure CLI method** [README](./cli/README.md)

--- a/cloud-service-providers/azure/blueprints/cds-blueprint-aks/README.md
+++ b/cloud-service-providers/azure/blueprints/cds-blueprint-aks/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained Azure samples are available at <https://github.com/NVIDIA/nvidia-azure-samples>.
+
 # CDS on AKS (Single GPU)
 
 NVIDIA Cosmos Dataset Search blueprint on Azure Kubernetes Service with a single GPU.

--- a/cloud-service-providers/azure/blueprints/vss-blueprint-aks/README.md
+++ b/cloud-service-providers/azure/blueprints/vss-blueprint-aks/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained Azure samples are available at <https://github.com/NVIDIA/nvidia-azure-samples>.
+
 # VSS on AKS (Single GPU)
 
 NVIDIA Video Search and Summarization blueprint on Azure Kubernetes Service with a single H100 GPU.

--- a/cloud-service-providers/azure/promptflow/README.md
+++ b/cloud-service-providers/azure/promptflow/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained Azure samples are available at <https://github.com/NVIDIA/nvidia-azure-samples>.
+
 # End to End LLM App development with Azure AI Studio, Prompt Flow and NIMs
 
  ![tl:dr](./images/contoso-chat-nim.png)
@@ -210,4 +213,3 @@ Let's run the flow to see what happens.  **Note that the input node is pre-confi
 - Click the `Prompt Flow` tab in the Visual Studio Code terminal window for execution times
 
 For more details on running the prompt flow, [follow the instructions here](https://microsoft.github.io/promptflow/how-to-guides/init-and-test-a-flow.html#test-a-flow).
-

--- a/cloud-service-providers/azure/workshops/aiq-rag-blueprint/README.md
+++ b/cloud-service-providers/azure/workshops/aiq-rag-blueprint/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained Azure samples are available at <https://github.com/NVIDIA/nvidia-azure-samples>.
+
 # Deploy NVIDIA AI-Q  Research Blueprint on Azure Kubernetes Service + Azure AI Foundry
 
 ![Azure_Cloud_Shell.png](imgs/AIQonAzureFoundry.png)

--- a/cloud-service-providers/azure/workshops/aks-dynamo/README.md
+++ b/cloud-service-providers/azure/workshops/aks-dynamo/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained Azure samples are available at <https://github.com/NVIDIA/nvidia-azure-samples>.
+
 # Configuring NVIDIA Dynamo on Azure Kubernetes Service (AKS) with Managed Prometheus
 
 This guide provides a comprehensive walkthrough for setting up NVIDIA Dynamo for disaggregated inference serving on Azure Kubernetes Service (AKS). You will learn how to configure GPU-accelerated node pools, integrate Azure Managed Prometheus for observability, and deploy the Dynamo platform to achieve optimized scaling and performance.
@@ -240,4 +243,3 @@ Users may observe the effect of the Disaggregate scaling in terms of important m
 The resulting graph shows TTFT metrics climb and then rapidly decline, which reflects the effects of the Disaggregate scaling:
 
 <img src="images/image-30.png" height="300" border=1>
-

--- a/cloud-service-providers/azure/workshops/aks-pvc-nim/README.md
+++ b/cloud-service-providers/azure/workshops/aks-pvc-nim/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained Azure samples are available at <https://github.com/NVIDIA/nvidia-azure-samples>.
+
 # Llama 3.1-8b  NIM Deployment Guide with AKS PVC Installation 
 
 ## Overview

--- a/cloud-service-providers/azure/workshops/cosmos-reason-on-ai-foundry/README.md
+++ b/cloud-service-providers/azure/workshops/cosmos-reason-on-ai-foundry/README.md
@@ -1,3 +1,5 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained Azure samples are available at <https://github.com/NVIDIA/nvidia-azure-samples>.
 
 # Overview
 NVIDIA Cosmos Reason – an open, customizable, 7B-parameter reasoning vision language model (VLM) for physical AI and robotics - enables robots and vision AI agents to reason like humans, using prior knowledge, physics understanding and common sense to understand and act in the real world. 

--- a/cloud-service-providers/azure/workshops/nim-aifoundry/README.md
+++ b/cloud-service-providers/azure/workshops/nim-aifoundry/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained Azure samples are available at <https://github.com/NVIDIA/nvidia-azure-samples>.
+
 # Deploy NVIDIA NIM on  Azure AI Foundry
 
 To learn more about NVIDIA NIM on  Azure AI Foundry: 

--- a/cloud-service-providers/azure/workshops/rag-aks/README.md
+++ b/cloud-service-providers/azure/workshops/rag-aks/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained Azure samples are available at <https://github.com/NVIDIA/nvidia-azure-samples>.
+
 # Deploy RAG application using NVIDIA NIMs and NeMo Retriever on Azure Kubernetes Service Workshop
 
   * Diagram
@@ -863,5 +866,4 @@ Be sure to check out the following articles for more information:
   * [NVIDIA GPUs](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/overview?tabs=breakdownseries%2Cgeneralsizelist%2Ccomputesizelist%2Cmemorysizelist%2Cstoragesizelist%2Cgpusizelist%2Cfpgasizelist%2Chpcsizelist#gpu-accelerated)
   * [NVIDIA AI Enterprise](https://console.cloud.Azure.com/marketplace/product/nvidia/nvidia-ai-enterprise-vmi)
   * [NVIDIA NIMs](https://www.nvidia.com/en-us/ai/)
-
 

--- a/cloud-service-providers/azure/workshops/rag-blueprint-aks/README.md
+++ b/cloud-service-providers/azure/workshops/rag-blueprint-aks/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained Azure samples are available at <https://github.com/NVIDIA/nvidia-azure-samples>.
+
 # Overview
 
 The NVIDIA RAG blueprint serves as a reference solution for a foundational Retrieval Augmented Generation (RAG) pipeline.


### PR DESCRIPTION
## Summary

- Mark the 12 Azure sample entry-point READMEs as deprecated in `nim-deploy`.
- Direct users to the maintained [`NVIDIA/nvidia-azure-samples`](https://github.com/NVIDIA/nvidia-azure-samples) repository.
- Preserve the existing sample code, notebooks, assets, nested setup documentation, and root README.

## Why

Azure samples are moving to their dedicated repository. These notices make the canonical maintenance location clear while keeping the existing copies available for reference, following the Google Cloud deprecation pattern from #216.

## Impact

Documentation only. Runtime behavior, APIs, configuration formats, and deployment assets are unchanged.

## Tests

- Verified exactly 12 Azure sample banners are present.
- Verified existing README body text is unchanged.
- Ran `git diff --check`.
- Ran the repository's configured private-key detection hook.
- Confirmed `https://github.com/NVIDIA/nvidia-azure-samples` returns HTTP 200.
- Verified commit `d822106` has a valid GPG signature.
