### PR TITLE
Deprecate AWS samples

### DIFF
--- a/cloud-service-providers/aws/README.md
+++ b/cloud-service-providers/aws/README.md
@@ -1,0 +1,4 @@
+# NVIDIA NIM on AWS
+
+> [!IMPORTANT]
+> These samples are deprecated and are no longer the canonical reference. New and maintained AWS samples are available at <https://github.com/NVIDIA/nvidia-aws-samples>.

--- a/cloud-service-providers/aws/blueprints/deep-research-blueprint-eks/README.md
+++ b/cloud-service-providers/aws/blueprints/deep-research-blueprint-eks/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained AWS samples are available at <https://github.com/NVIDIA/nvidia-aws-samples>.
+
 # AI-Q Blueprint Deployment on AWS Elastic Kubernetes Service (EKS)
 
 This guide shows how to deploy the [NVIDIA AI-Q Research Assistant Blueprint](https://build.nvidia.com/nvidia/aiq) on Amazon Elastic Kubernetes Service (EKS). For more detailed deployment information about the AI-Q Research assistant blueprint, see the [github repository](https://github.com/NVIDIA-AI-Blueprints/aiq-research-assistant)

--- a/cloud-service-providers/aws/blueprints/deep-research-blueprint-eks/opensearch/README.md
+++ b/cloud-service-providers/aws/blueprints/deep-research-blueprint-eks/opensearch/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained AWS samples are available at <https://github.com/NVIDIA/nvidia-aws-samples>.
+
 # OpenSearch Integration Guide for AI-Q Blueprint on EKS
 
 This guide covers the integration of Amazon OpenSearch Serverless with the NVIDIA AI-Q Research Assistant Blueprint on Amazon EKS.

--- a/cloud-service-providers/aws/blueprints/rag-blueprint-eks/README.md
+++ b/cloud-service-providers/aws/blueprints/rag-blueprint-eks/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained AWS samples are available at <https://github.com/NVIDIA/nvidia-aws-samples>.
+
 # Deploy NVIDIA Enterprise RAG Blueprint on Amazon Elastic Kubernetes Service (EKS) Workshop
 
 ## Table of Contents

--- a/cloud-service-providers/aws/blueprints/rag-blueprint-eks/opensearch/README.md
+++ b/cloud-service-providers/aws/blueprints/rag-blueprint-eks/opensearch/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained AWS samples are available at <https://github.com/NVIDIA/nvidia-aws-samples>.
+
 # OpenSearch Integration Guide for Enterprise RAG Blueprint on EKS
 
 This guide covers the integration of Amazon OpenSearch Serverless with the NVIDIA Enterprise RAG Blueprint on Amazon EKS.

--- a/cloud-service-providers/aws/eks/README.md
+++ b/cloud-service-providers/aws/eks/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained AWS samples are available at <https://github.com/NVIDIA/nvidia-aws-samples>.
+
 # NVIDIA NIM on AWS EKS:
 
 This repository is dedicated to testing NVIDIA NIM on AWS EKS (Elastic Kubernetes Service).

--- a/cloud-service-providers/aws/sagemaker/README.md
+++ b/cloud-service-providers/aws/sagemaker/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained AWS samples are available at <https://github.com/NVIDIA/nvidia-aws-samples>.
+
 # NVIDIA NIM on AWS Sagemaker
 
 ## Overview

--- a/cloud-service-providers/aws/sagemaker/README_jupyter.md
+++ b/cloud-service-providers/aws/sagemaker/README_jupyter.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained AWS samples are available at <https://github.com/NVIDIA/nvidia-aws-samples>.
+
 # NVIDIA NIM on AWS Sagemaker
 
 ## AWS Sagemaker Notebook Configuration

--- a/cloud-service-providers/aws/sagemaker/README_python.md
+++ b/cloud-service-providers/aws/sagemaker/README_python.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained AWS samples are available at <https://github.com/NVIDIA/nvidia-aws-samples>.
+
 # NVIDIA NIM on AWS Sagemaker
 
 ## Overview

--- a/cloud-service-providers/aws/sagemaker/README_shell.md
+++ b/cloud-service-providers/aws/sagemaker/README_shell.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained AWS samples are available at <https://github.com/NVIDIA/nvidia-aws-samples>.
+
 # NVIDIA NIM on AWS Sagemaker
 
 ## Overview

--- a/cloud-service-providers/aws/sagemaker/aws_marketplace_notebooks/README.md
+++ b/cloud-service-providers/aws/sagemaker/aws_marketplace_notebooks/README.md
@@ -1,0 +1,4 @@
+# AWS Marketplace Notebooks
+
+> [!IMPORTANT]
+> These samples are deprecated and are no longer the canonical reference. New and maintained AWS samples are available at <https://github.com/NVIDIA/nvidia-aws-samples>.

--- a/cloud-service-providers/aws/sagemaker/deployment_notebooks/README.md
+++ b/cloud-service-providers/aws/sagemaker/deployment_notebooks/README.md
@@ -1,0 +1,4 @@
+# SageMaker Deployment Notebooks
+
+> [!IMPORTANT]
+> These samples are deprecated and are no longer the canonical reference. New and maintained AWS samples are available at <https://github.com/NVIDIA/nvidia-aws-samples>.

--- a/cloud-service-providers/aws/sagemaker/s3_nim_sagemaker/README.md
+++ b/cloud-service-providers/aws/sagemaker/s3_nim_sagemaker/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained AWS samples are available at <https://github.com/NVIDIA/nvidia-aws-samples>.
+
 # NVIDIA NIM Deployment on SageMaker with S3 NIM Storage
 
 ## Overview

--- a/cloud-service-providers/aws/workshops/rag-eks/README.md
+++ b/cloud-service-providers/aws/workshops/rag-eks/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This sample is deprecated and is no longer the canonical reference. New and maintained AWS samples are available at <https://github.com/NVIDIA/nvidia-aws-samples>.
+
 # Deploy RAG application using NVIDIA LLM and NeMo Retriever NIMs on Amazon Elastic Kubernetes Service (EKS) Workshop
 
 ## Table of Contents


### PR DESCRIPTION
## Summary

- Mark the 11 AWS sample entry-point READMEs as deprecated in `nim-deploy`.
- Direct users to the maintained [`NVIDIA/nvidia-aws-samples`](https://github.com/NVIDIA/nvidia-aws-samples) repository.
- Preserve the existing sample code, notebooks, assets, nested setup documentation, and root README.

## Why

AWS samples are moving to their dedicated repository. These notices make the canonical maintenance location clear while keeping the existing copies available for reference, following the Google Cloud (#216) and Azure (#217) deprecation pattern.

## Impact

Documentation only. Runtime behavior, APIs, configuration formats, and deployment assets are unchanged.

## Tests

- Verified exactly 11 AWS sample banners are present.
- Verified existing README body text is unchanged.
- Ran `git diff --check` (clean).
- Confirmed `https://github.com/NVIDIA/nvidia-aws-samples` is reachable.